### PR TITLE
Add missing interpolation syntax

### DIFF
--- a/reference/01-conditionals.adoc
+++ b/reference/01-conditionals.adoc
@@ -11,7 +11,7 @@ Edge has first-class support for conditionals via `if` and `unless` tags.
 [source, edge]
 ----
 @if(username)
-  <h2> Hello username </h2>
+  <h2> Hello {{ username }} </h2>
 @endif
 ----
 


### PR DESCRIPTION
The example doesn't make sense without this being interpolation. This change makes the example fit more with following examples.